### PR TITLE
Remove Egor from Rockstar speakers

### DIFF
--- a/machine-learning-2017/_data/speakers.yml
+++ b/machine-learning-2017/_data/speakers.yml
@@ -24,7 +24,7 @@ In the past Vadim was also a visiting associate professor at Moscow Institute of
 
 In the past Egor was a robotics engineer whose responsibility was to develop the computer vision system for an unmanned air vehicle while studying at Bauman Moscow State Technical University. He used to be an active participant of international robotics competition Eurobot."
   thumbnailUrl: Egor-Bulychev.jpg
-  rockstar: true
+  rockstar: false
   social:
     - {name: "linkedin", link: "https://linkedin.com/in/egor-bulychev-028237118"}
     - {name: "twitter", link: "https://twitter.com/egor_bu"}


### PR DESCRIPTION
As @vmarkovtsev requested in #41, Egor gets a `rockstar: false` so Charles Sutton is always _randomly_ selected.

For this to be true always, there cannot be more than 4 rockstar developers.

Rockstar developers is a crappy name, unless they do a lot of cocaine and demand a bowl of only red M&Ms.

Fixes #41 