### PR TITLE
Added helm chart

### DIFF
--- a/helm-charts/talks/.helmignore
+++ b/helm-charts/talks/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm-charts/talks/Chart.yaml
+++ b/helm-charts/talks/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: talks
+version: 0.1.0

--- a/helm-charts/talks/README.md
+++ b/helm-charts/talks/README.md
@@ -1,0 +1,34 @@
+# source{d} talks deployment
+
+This is the [Helm](https://helm.sh/) chart to deploy [source{d} talks](https://talks.sourced.tech) in kubernetes.
+
+# Installing the Chart
+
+To manually install the chart, run:
+
+```bash
+$ helm install --name <release-name> <path-to-chart> --set \
+  image.tag==<label>,\
+  ingress.globalStaticIpName=<static-ip>,\
+  ingress.hosts={talks.srcd.run}
+```
+
+These are the mandatory parameters that need to be provided or installation will fail.
+Other parameters can be provided too but, if not, a default value will be used.
+
+# Configuration
+
+Please refer to [values.yaml](values.yaml) for the full run-down on defaults.
+
+To override any of those default values,
+specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided
+while installing the chart.
+For example,
+
+```bash
+$ helm install --name <release-name> -f values.yaml <path-to-chart>
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/helm-charts/talks/templates/NOTES.txt
+++ b/helm-charts/talks/templates/NOTES.txt
@@ -1,0 +1,17 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.hostname }}
+  http://{{- .Values.ingress.hostname }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
+{{- end }}

--- a/helm-charts/talks/templates/_helpers.tpl
+++ b/helm-charts/talks/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm-charts/talks/templates/deployment.yaml
+++ b/helm-charts/talks/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ required "Missing .Values.image.repository" .Values.image.repository }}:{{ required "Missing .Values.image.tag" .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.internalPort }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/helm-charts/talks/templates/ingress.yaml
+++ b/helm-charts/talks/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- $serviceName := include "fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+      kubernetes.io/ingress.global-static-ip-name: {{ required "Missing .Values.ingress.globalStaticIpName" .Values.ingress.globalStaticIpName }}
+spec:
+  rules:
+    {{- range $host :=  required "Missing .Values.ingress.hosts" .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - secretName: "{{ template "fullname" . }}-tls"
+      hosts:
+      {{- range $host :=  required "Missing .Values.ingress.hosts" .Values.ingress.hosts }}
+        - {{ $host }}
+      {{- end }}
+   {{- end }}

--- a/helm-charts/talks/templates/service.yaml
+++ b/helm-charts/talks/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/helm-charts/talks/values.yaml
+++ b/helm-charts/talks/values.yaml
@@ -1,0 +1,32 @@
+# Default values for talks.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: quay.io/srcd/talks
+#  tag: master
+  pullPolicy: IfNotPresent
+service:
+  name: talks
+  type: NodePort
+  externalPort: 8080
+  internalPort: 8080
+ingress:
+  annotations:
+    kubernetes.io/ingress.class: gce
+    kubernetes.io/tls-acme: "true"
+  tls: true
+  # hosts:
+  # - talks.sourced.tech
+  # globalStaticIpName: "talks-ip"
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious 
+  # choice for the user. This also increases chances charts run on environments with little 
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following 
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  #requests:
+  #  cpu: 100m
+  #  memory: 128Mi


### PR DESCRIPTION
This chart depends on #70 work. I've chose not to fork from it as it is a complete independent job but this will not work until that PR is merged, hence it is tagged as `do not merge` for that reason

Redirection is missing from the moment. I will add it once everything is merged

https://talks.srcd.run

Deployed using the docker containers I've created using unmerged #70
```
$ helm install  -n test-talks . --set "ingress.hosts={talks.srcd.run},ingress.globalStaticIpName=talks-srcd-run,image.repository=quay.io/rporres/talks,image.tag=master"
NAME:   test-talks
LAST DEPLOYED: Tue Aug 22 16:51:13 2017
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME              CLUSTER-IP   EXTERNAL-IP  PORT(S)         AGE
test-talks-talks  10.7.241.73  <nodes>      8080:31165/TCP  0s

==> v1beta1/Deployment
NAME              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
test-talks-talks  1        1        1           0          0s

==> v1beta1/Ingress
NAME              HOSTS           ADDRESS  PORTS  AGE
test-talks-talks  talks.srcd.run  80, 443  0s


NOTES:
1. Get the application URL by running these commands:
  export NODE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services test-talks-talks)
  export NODE_IP=$(kubectl get nodes --namespace default -o jsonpath="{.items[0].status.addresses[0].address}")
  echo http://$NODE_IP:$NODE_PORT